### PR TITLE
Add Supabase configuration and schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Environment configuration for the backend
+
+# URL of your Supabase instance
+SUPABASE_URL=
+
+# Service role key for accessing Supabase
+SUPABASE_SERVICE_KEY=

--- a/backend/src/database/supabaseClient.js
+++ b/backend/src/database/supabaseClient.js
@@ -1,0 +1,17 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('Supabase environment variables are not set');
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false
+  }
+});
+
+module.exports = supabase;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,25 @@
+-- SQL schema for Supabase PostgreSQL
+
+create table if not exists contacts (
+  id uuid primary key default uuid_generate_v4(),
+  created_at timestamp with time zone default now(),
+  first_name text,
+  last_name text,
+  phone text not null unique
+);
+
+create table if not exists campaigns (
+  id uuid primary key default uuid_generate_v4(),
+  created_at timestamp with time zone default now(),
+  name text not null,
+  message text
+);
+
+create table if not exists coupon_codes (
+  id uuid primary key default uuid_generate_v4(),
+  created_at timestamp with time zone default now(),
+  code text not null unique,
+  redeemed boolean default false,
+  contact_id uuid references contacts(id),
+  campaign_id uuid references campaigns(id)
+);


### PR DESCRIPTION
## Summary
- set up Supabase client under `backend/src/database`
- document environment variables for Supabase
- provide SQL schema with `contacts`, `campaigns`, and `coupon_codes` tables

## Testing
- `npm test` *(fails: package.json missing)*