### PR TITLE
Implement SMS campaign worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# SMS Campaign Worker
+
+This project demonstrates a BullMQ worker that schedules SMS campaigns stored in a SQLite database.
+
+## Usage
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the worker:
+
+```bash
+npm start
+```
+
+The worker periodically checks for pending messages to send, schedules messages based on campaign definitions, and runs a daily job to remind users of unused coupons older than three days.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sms-campaign-worker",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "bullmq": "^4.0.0",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,37 @@
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+export async function initDb() {
+  const db = await open({ filename: 'data.db', driver: sqlite3.Database });
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS campaigns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      steps TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS campaign_assignments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      campaign_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      assigned_at DATETIME NOT NULL,
+      FOREIGN KEY(campaign_id) REFERENCES campaigns(id)
+    );
+    CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      campaign_assignment_id INTEGER NOT NULL,
+      step_index INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      scheduled_at DATETIME NOT NULL,
+      sent_at DATETIME,
+      FOREIGN KEY(campaign_assignment_id) REFERENCES campaign_assignments(id)
+    );
+    CREATE TABLE IF NOT EXISTS coupons (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      code TEXT NOT NULL,
+      used INTEGER DEFAULT 0,
+      created_at DATETIME NOT NULL
+    );
+  `);
+  return db;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,34 @@
+import { startWorker, scheduleCampaignMessages } from './worker.js';
+import { initDb } from './db.js';
+
+async function main() {
+  const db = await initDb();
+  await startWorker();
+
+  // Example: create a campaign if none exists
+  const existing = await db.get('SELECT id FROM campaigns LIMIT 1');
+  if (!existing) {
+    const steps = JSON.stringify([
+      { delay: 0, message: 'Welcome to our campaign!' },
+      { delay: 60, message: 'Second message after 1 minute' },
+    ]);
+    await db.run('INSERT INTO campaigns (name, steps) VALUES (?, ?)', 'Welcome', steps);
+    console.log('Default campaign created');
+  }
+
+  // Example assignment
+  const campaign = await db.get('SELECT id FROM campaigns LIMIT 1');
+  const assignment = await db.get('SELECT id FROM campaign_assignments LIMIT 1');
+  if (!assignment && campaign) {
+    const result = await db.run(
+      'INSERT INTO campaign_assignments (campaign_id, user_id, assigned_at) VALUES (?, ?, ?)',
+      campaign.id,
+      1,
+      new Date().toISOString()
+    );
+    await scheduleCampaignMessages(result.lastID);
+    console.log('Campaign assignment created');
+  }
+}
+
+main().catch(err => console.error(err));

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,87 @@
+import { Worker, Queue, QueueScheduler, Job } from 'bullmq';
+import { initDb } from './db.js';
+
+const connection = {
+  host: 'localhost',
+  port: 6379,
+};
+
+export async function startWorker() {
+  const db = await initDb();
+  const smsQueue = new Queue('sms', { connection });
+  new QueueScheduler('sms', { connection });
+
+  // Process SMS sending
+  new Worker(
+    'sms',
+    async job => {
+      const { id } = job.data;
+      const message = await db.get('SELECT * FROM messages WHERE id = ?', id);
+      if (!message) return;
+      // Simulate SMS sending
+      console.log(`Sending SMS for message ${id}`);
+      await db.run('UPDATE messages SET status = ?, sent_at = ? WHERE id = ?', 'sent', new Date().toISOString(), id);
+    },
+    { connection }
+  );
+
+  // Periodically check for pending messages
+  setInterval(async () => {
+    const now = new Date().toISOString();
+    const pending = await db.all('SELECT id FROM messages WHERE status = ? AND scheduled_at <= ?', 'pending', now);
+    for (const row of pending) {
+      await smsQueue.add('send-sms', { id: row.id });
+    }
+  }, 1000 * 60);
+
+  // Daily job to remind about unused coupons
+  const dailyQueue = new Queue('daily', { connection });
+  new QueueScheduler('daily', { connection });
+  new Worker(
+    'daily',
+    async () => {
+      const cutoff = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      const coupons = await db.all('SELECT id, user_id FROM coupons WHERE used = 0 AND created_at <= ?', cutoff);
+      for (const c of coupons) {
+        const id = await db.run(
+          'INSERT INTO messages (campaign_assignment_id, step_index, status, scheduled_at) VALUES (?, ?, ?, ?)',
+          0,
+          0,
+          'pending',
+          new Date().toISOString()
+        );
+        await smsQueue.add('send-sms', { id: id.lastID });
+        console.log(`Reminder for coupon ${c.id} queued`);
+      }
+    },
+    { connection }
+  );
+
+  await dailyQueue.add(
+    'check-coupons',
+    {},
+    {
+      repeat: { cron: '0 0 * * *' },
+    }
+  );
+}
+
+export async function scheduleCampaignMessages(assignmentId) {
+  const db = await initDb();
+  const assignment = await db.get('SELECT * FROM campaign_assignments WHERE id = ?', assignmentId);
+  if (!assignment) return;
+  const campaign = await db.get('SELECT * FROM campaigns WHERE id = ?', assignment.campaign_id);
+  if (!campaign) return;
+  const steps = JSON.parse(campaign.steps);
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const scheduled = new Date(new Date(assignment.assigned_at).getTime() + step.delay * 1000);
+    await db.run(
+      'INSERT INTO messages (campaign_assignment_id, step_index, status, scheduled_at) VALUES (?, ?, ?, ?)',
+      assignmentId,
+      i,
+      'pending',
+      scheduled.toISOString()
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add BullMQ-based worker and example campaign assignment
- store campaigns in sqlite with JSON steps
- track campaign assignments and messages
- include a daily job to remind about unused coupons

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: EHOSTUNREACH)*